### PR TITLE
Initial support for a gutter around the border, from A19 to T1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For a textured board, add the class `tenuki-board-textured`:
 
 # Other board sizes
 
-You can pass a second argument to `new tenuki.Board` to specify the board size. If no size is given, the default of 19 is used. In theory any size should work, although star points have only been designed for 9x9, 13x13 and 19x19 boards.
+You can pass a second argument to `new tenuki.Board` to specify the board size. If no size is given, the default of 19 is used. All sizes between 1x1 and 19x19 should work, although star points have only been designed for 9x9, 13x13 and 19x19 boards. Sizes above 19x19 will error and won't render.
 
 ```js
 // use a 13x13 board

--- a/build/tenuki.css
+++ b/build/tenuki.css
@@ -7,29 +7,88 @@
   position: absolute;
   top: 0;
   left: 0;
-
   margin: 18px;
+}
+
+.tenuki-board[data-include-gutter=true] .lines {
+  margin: calc(18px + 25px);
 }
 
 .tenuki-board .line {
   background: rgb(135, 113, 63);
+  float: left;
+  position: relative;
 }
 
 .tenuki-board .line.horizontal {
   height: 1px;
   width: 100%;
   margin-bottom: 28px;
+  clear: left;
 }
 
 .tenuki-board .line.vertical {
   width: 1px;
   height: 100%;
-  float: left;
   margin-right: 28px;
 }
 
 .tenuki-board .line.vertical:last-child {
   margin-right: -1px;
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:before,
+.tenuki-board[data-include-gutter=true] .line.vertical:after,
+.tenuki-board[data-include-gutter=true] .line.horizontal:before,
+.tenuki-board[data-include-gutter=true] .line.horizontal:after {
+  width: calc(25px - 5px);
+  height: calc(25px - 5px);
+  text-align: center;
+  line-height: calc(25px - 5px);
+  font-family: sans-serif;
+  color: rgb(135, 113, 63);
+  display: block;
+  font-size: 14px;
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:before,
+.tenuki-board[data-include-gutter=true] .line.vertical:after {
+  content: attr(data-top-gutter);
+}
+
+.tenuki-board[data-include-gutter=true] .line.horizontal:before,
+.tenuki-board[data-include-gutter=true] .line.horizontal:after {
+  content: attr(data-left-gutter);
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:before {
+  margin-left: calc(-1*(25px - 5px)/2);
+  /* take off the width of 1 stone, then extra distance */
+  margin-top: calc(-1*(25px - 5px)/2 - 28px);
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:after {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin-left: calc(-1*(25px - 5px)/2);
+  /* take off the width of 1 stone, then extra distance */
+  margin-bottom: calc(-1*(25px - 5px)/2 - 28px);
+}
+
+.tenuki-board[data-include-gutter=true] .line.horizontal:before {
+  /* take off the width of 1 stone, then extra distance */
+  margin-left: calc(-1*(25px - 5px)/2 - 28px);
+  margin-top: calc(-1*(25px - 5px)/2);
+}
+
+.tenuki-board[data-include-gutter=true] .line.horizontal:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  /* take off the width of 1 stone, then extra distance */
+  margin-right: calc(-1*(25px - 5px)/2 - 28px);
+  margin-top: calc(-1*(25px - 5px)/2);
 }
 
 .tenuki-board .hoshi {
@@ -44,6 +103,11 @@
   position: absolute;
   top: calc(18px - 28px/2);
   left: calc(18px - 28px/2);
+}
+
+.tenuki-board[data-include-gutter=true] .intersections {
+  margin-top: 25px;
+  margin-left: 25px;
 }
 
 .tenuki-board .intersection {

--- a/build/tenuki.js
+++ b/build/tenuki.js
@@ -11,8 +11,9 @@ exports.utils = require("./lib/utils");
 var utils = require("./utils");
 
 var BoardRenderer = function(board, boardElement) {
-  this.MARGIN = 18;
   this.STONE_WIDTH = 28;
+  this.GUTTER_MARGIN = 25;
+  this.MARGIN = boardElement.hasAttribute("data-include-gutter") ? 18 + this.GUTTER_MARGIN : 18;
   this.board = board;
   this.boardElement = boardElement;
   this.grid = [];
@@ -65,9 +66,11 @@ var BoardRenderer = function(board, boardElement) {
 
     for (var y = 0; y < board.size; y++) {
       var horizontalLine = utils.createElement("div", { class: "line horizontal" });
+      horizontalLine.setAttribute("data-left-gutter", board.yCoordinateFor(y));
       utils.appendElement(boardElement.querySelector(".lines.horizontal"), horizontalLine);
 
       var verticalLine = utils.createElement("div", { class: "line vertical" });
+      verticalLine.setAttribute("data-top-gutter", board.xCoordinateFor(y))
       utils.appendElement(boardElement.querySelector(".lines.vertical"), verticalLine);
 
       for (var x = 0; x < board.size; x++) {
@@ -254,6 +257,10 @@ var Board = function(element, size) {
   this.setup = function() {
     var board = this;
 
+    if (board.size > 19) {
+      throw "cannot generate a board size greater than 19";
+    }
+
     board.renderer.setup();
 
     for (var y = 0; y < board.size; y++) {
@@ -275,12 +282,23 @@ var Board = function(element, size) {
     return utils.flatten(this.intersectionGrid);
   };
 
+  this.yCoordinateFor = function(y) {
+    return board.size - y;
+  };
+
+  this.xCoordinateFor = function(x) {
+    letters = ["A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T"];
+
+    return letters[x];
+  };
+
   this.stateFor = function(y, x, captures) {
     var board = this;
 
     var moveInfo = {
       y: y,
       x: x,
+      coordinates: this.xCoordinateFor(x) + this.yCoordinateFor(y),
       color: board.currentPlayer,
       pass: false,
       points: board.intersections().map(function(i) { return i.duplicate(); }),
@@ -314,6 +332,7 @@ var Board = function(element, size) {
     return {
       y: null,
       x: null,
+      coordinates: null,
       color: board.currentPlayer,
       pass: true,
       points: board.intersections().map(function(i) { return i.duplicate(); }),

--- a/css/board.css
+++ b/css/board.css
@@ -7,29 +7,88 @@
   position: absolute;
   top: 0;
   left: 0;
-
   margin: 18px;
+}
+
+.tenuki-board[data-include-gutter=true] .lines {
+  margin: calc(18px + 25px);
 }
 
 .tenuki-board .line {
   background: rgb(135, 113, 63);
+  float: left;
+  position: relative;
 }
 
 .tenuki-board .line.horizontal {
   height: 1px;
   width: 100%;
   margin-bottom: 28px;
+  clear: left;
 }
 
 .tenuki-board .line.vertical {
   width: 1px;
   height: 100%;
-  float: left;
   margin-right: 28px;
 }
 
 .tenuki-board .line.vertical:last-child {
   margin-right: -1px;
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:before,
+.tenuki-board[data-include-gutter=true] .line.vertical:after,
+.tenuki-board[data-include-gutter=true] .line.horizontal:before,
+.tenuki-board[data-include-gutter=true] .line.horizontal:after {
+  width: calc(25px - 5px);
+  height: calc(25px - 5px);
+  text-align: center;
+  line-height: calc(25px - 5px);
+  font-family: sans-serif;
+  color: rgb(135, 113, 63);
+  display: block;
+  font-size: 14px;
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:before,
+.tenuki-board[data-include-gutter=true] .line.vertical:after {
+  content: attr(data-top-gutter);
+}
+
+.tenuki-board[data-include-gutter=true] .line.horizontal:before,
+.tenuki-board[data-include-gutter=true] .line.horizontal:after {
+  content: attr(data-left-gutter);
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:before {
+  margin-left: calc(-1*(25px - 5px)/2);
+  /* take off the width of 1 stone, then extra distance */
+  margin-top: calc(-1*(25px - 5px)/2 - 28px);
+}
+
+.tenuki-board[data-include-gutter=true] .line.vertical:after {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin-left: calc(-1*(25px - 5px)/2);
+  /* take off the width of 1 stone, then extra distance */
+  margin-bottom: calc(-1*(25px - 5px)/2 - 28px);
+}
+
+.tenuki-board[data-include-gutter=true] .line.horizontal:before {
+  /* take off the width of 1 stone, then extra distance */
+  margin-left: calc(-1*(25px - 5px)/2 - 28px);
+  margin-top: calc(-1*(25px - 5px)/2);
+}
+
+.tenuki-board[data-include-gutter=true] .line.horizontal:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  /* take off the width of 1 stone, then extra distance */
+  margin-right: calc(-1*(25px - 5px)/2 - 28px);
+  margin-top: calc(-1*(25px - 5px)/2);
 }
 
 .tenuki-board .hoshi {
@@ -44,6 +103,11 @@
   position: absolute;
   top: calc(18px - 28px/2);
   left: calc(18px - 28px/2);
+}
+
+.tenuki-board[data-include-gutter=true] .intersections {
+  margin-top: 25px;
+  margin-left: 25px;
 }
 
 .tenuki-board .intersection {

--- a/examples/example_with_simple_controls_and_gutter.html
+++ b/examples/example_with_simple_controls_and_gutter.html
@@ -52,7 +52,7 @@
 </style>
 </head>
 
-<div class="tenuki-board"></div>
+<div class="tenuki-board" data-include-gutter=true></div>
 
 <div class="controls">
   <div class="buttons">
@@ -92,7 +92,9 @@ ExampleBoardControls = function(element, board) {
     if (currentMove) {
       var player = currentMove.color[0].toUpperCase() + currentMove.color.substr(1);
 
-      if (currentMove.pass) {
+      if (!currentMove.pass) {
+        newGameInfo += player + " played " + currentMove.coordinates;
+      } else {
         newGameInfo += player + " passed."
       }
     }
@@ -153,6 +155,6 @@ var controls = new ExampleBoardControls(controlElement, board);
 controls.setup();
 
 board.callbacks.postRender = function(board) {
-	controls.updateStats();
+  controls.updateStats();
 };
 </script>

--- a/lib/board-renderer.js
+++ b/lib/board-renderer.js
@@ -1,8 +1,9 @@
 var utils = require("./utils");
 
 var BoardRenderer = function(board, boardElement) {
-  this.MARGIN = 18;
   this.STONE_WIDTH = 28;
+  this.GUTTER_MARGIN = 25;
+  this.MARGIN = boardElement.hasAttribute("data-include-gutter") ? 18 + this.GUTTER_MARGIN : 18;
   this.board = board;
   this.boardElement = boardElement;
   this.grid = [];
@@ -55,9 +56,11 @@ var BoardRenderer = function(board, boardElement) {
 
     for (var y = 0; y < board.size; y++) {
       var horizontalLine = utils.createElement("div", { class: "line horizontal" });
+      horizontalLine.setAttribute("data-left-gutter", board.yCoordinateFor(y));
       utils.appendElement(boardElement.querySelector(".lines.horizontal"), horizontalLine);
 
       var verticalLine = utils.createElement("div", { class: "line vertical" });
+      verticalLine.setAttribute("data-top-gutter", board.xCoordinateFor(y))
       utils.appendElement(boardElement.querySelector(".lines.vertical"), verticalLine);
 
       for (var x = 0; x < board.size; x++) {

--- a/lib/board.js
+++ b/lib/board.js
@@ -23,6 +23,10 @@ var Board = function(element, size) {
   this.setup = function() {
     var board = this;
 
+    if (board.size > 19) {
+      throw "cannot generate a board size greater than 19";
+    }
+
     board.renderer.setup();
 
     for (var y = 0; y < board.size; y++) {
@@ -44,12 +48,23 @@ var Board = function(element, size) {
     return utils.flatten(this.intersectionGrid);
   };
 
+  this.yCoordinateFor = function(y) {
+    return board.size - y;
+  };
+
+  this.xCoordinateFor = function(x) {
+    letters = ["A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T"];
+
+    return letters[x];
+  };
+
   this.stateFor = function(y, x, captures) {
     var board = this;
 
     var moveInfo = {
       y: y,
       x: x,
+      coordinates: this.xCoordinateFor(x) + this.yCoordinateFor(y),
       color: board.currentPlayer,
       pass: false,
       points: board.intersections().map(function(i) { return i.duplicate(); }),
@@ -83,6 +98,7 @@ var Board = function(element, size) {
     return {
       y: null,
       x: null,
+      coordinates: null,
       color: board.currentPlayer,
       pass: true,
       points: board.intersections().map(function(i) { return i.duplicate(); }),


### PR DESCRIPTION
Adding `data-include-gutter=true` to the `.tenuki-board` HTML element will generate a gutter containing coordinates for each intersection.

<img width="207" alt="screen shot 2016-04-02 at 00 41 01" src="https://cloud.githubusercontent.com/assets/342081/14224472/afbb4770-f86b-11e5-81d7-3eeba805e4a0.png">