### PR TITLE
More gracefully handle smaller screens and touch devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Features:
   * Ko rule.
   * Pass.
   * Undo.
+  * Built-in mobile support for touch devices and small screens, even with a 19x19 board.
   * End-game detection: dead stone marking, area/territory scoring.
 
 The go board provides a JavaScript interface to perform various functions, but the UI for individual controls is left to you.
@@ -25,6 +26,8 @@ For live examples, see `examples/`, or view them on GitHub:
 
 * [`example.html`](https://aprescott.github.io/tenuki.js/examples/example.html) — Just the board.
 * [`example_with_simple_controls.html`](https://aprescott.github.io/tenuki.js/examples/example_with_simple_controls.html) — Board with an example of simple custom controls and updating game info.
+
+These examples are also set up to work on mobile/touch displays.
 
 # Simple usage
 

--- a/build/tenuki.css
+++ b/build/tenuki.css
@@ -1,6 +1,60 @@
 .tenuki-board {
   position: relative;
+  -webkit-user-select: none;
+}
+
+.tenuki-board .tenuki-inner-container {
   background: rgb(226, 188, 106);
+  overflow: hidden;
+}
+
+.tenuki-board .tenuki-zoom-container {
+  transition: transform 0.2s ease-in-out;
+  /*
+   * address an issue somewhat related to the shrink-to-fit problem on iOS 9: https://forums.developer.apple.com/thread/13510
+   * by setting this initial scale, any subsequent shrinking will not leave whitespace on the right of the board, which leads
+   * to a horizontal scrollbar
+   */
+  transform: scale(1);
+}
+
+.tenuki-board.tenuki-scaled .cancel-zoom.visible {
+  background: #B95858;
+  height: 70px;
+  width: 20px;
+  position: absolute;
+  transform: rotateZ(45deg);
+  bottom: 62px;
+  left: 89px;
+  z-index: 2;
+}
+
+.tenuki-board.tenuki-scaled .cancel-zoom.visible:after {
+  background: #B95858;
+  content: "";
+  height: 20px;
+  left: -25px;
+  position: absolute;
+  top: 25px;
+  width: 70px;
+}
+
+.tenuki-board.tenuki-scaled .cancel-zoom.visible + .cancel-zoom-backdrop {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  z-index: 1;
+  bottom: 48px;
+  left: 49px;
+  background: rgba(226, 188, 106, 0.81);
+  border-radius: 50%;
+}
+
+.tenuki-board[data-include-gutter=true] .cancel-zoom.visible,
+.tenuki-board[data-include-gutter=true] .cancel-zoom.visible + .cancel-zoom-backdrop {
+  /* additional gutter margin offset */
+  margin-left: calc(28px - 3px);
+  margin-bottom: calc(28px - 3px);
 }
 
 .tenuki-board .lines {
@@ -187,7 +241,7 @@
   height: 100%;
 }
 
-.tenuki-board .intersection.empty:hover .highlight {
+.tenuki-board .intersection.empty.hovered .highlight {
   display: block;
   /* stone width without border */
   width: calc(28px - 1px);
@@ -197,13 +251,13 @@
   opacity: 0.5;
 }
 
-.tenuki-board.white-to-play .intersection.empty:hover .highlight,
-.tenuki-board.black-to-play .intersection.empty:hover .highlight {
+.tenuki-board.white-to-play .intersection.empty.hovered .highlight,
+.tenuki-board.black-to-play .intersection.empty.hovered .highlight {
   background: black;
   border: 1px solid black;
 }
 
-.tenuki-board.white-to-play .intersection.empty:hover .highlight {
+.tenuki-board.white-to-play .intersection.empty.hovered .highlight {
   background: white;
 }
 
@@ -268,13 +322,13 @@
 }
 
 .tenuki-board-textured .stone.black,
-.tenuki-board-textured.black-to-play .intersection.empty:hover .highlight {
+.tenuki-board-textured.black-to-play .intersection.empty.hovered .highlight {
   border-color: #565656;
   background: radial-gradient(circle at 50% 120%, #000000, #484848 10%, #101010 80%, #FFFFFF 100%);
 }
 
 .tenuki-board-textured .stone.white,
-.tenuki-board-textured.white-to-play .intersection.empty:hover .highlight {
+.tenuki-board-textured.white-to-play .intersection.empty.hovered .highlight {
   border-color: #DEDEDE;
   background: radial-gradient(circle at 50% 120%, #ECEAEA, #D6D6D6 10%, #EAEAEA 80%, #FFFFFF 100%);
 }

--- a/build/tenuki.js
+++ b/build/tenuki.js
@@ -18,16 +18,36 @@ var DOMRenderer = function(game, boardElement) {
   this.game = game;
   this.boardElement = boardElement;
   this.grid = [];
+  this.touchEventFired = false;
 
   this.setup = function() {
     var renderer = this;
     var game = renderer.game;
     var boardElement = this.boardElement;
 
-    utils.appendElement(boardElement, utils.createElement("div", { class: "lines horizontal" }));
-    utils.appendElement(boardElement, utils.createElement("div", { class: "lines vertical" }));
-    utils.appendElement(boardElement, utils.createElement("div", { class: "hoshi-points" }));
-    utils.appendElement(boardElement, utils.createElement("div", { class: "intersections" }));
+    var innerContainer = utils.createElement("div", { class: "tenuki-inner-container" });
+    renderer.innerContainer = innerContainer;
+    utils.appendElement(boardElement, innerContainer);
+
+    var zoomContainer = utils.createElement("div", { class: "tenuki-zoom-container" });
+    renderer.zoomContainer = zoomContainer;
+    utils.appendElement(innerContainer, zoomContainer);
+
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "lines horizontal" }));
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "lines vertical" }));
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "hoshi-points" }));
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "intersections" }));
+
+    renderer.cancelZoomElement = utils.createElement("div", { class: "cancel-zoom" });
+    cancelZoomBackdrop = utils.createElement("div", { class: "cancel-zoom-backdrop" });
+    utils.addEventListener(renderer.cancelZoomElement, "click", function(e) {
+      renderer.zoomOut();
+    });
+    utils.addEventListener(cancelZoomBackdrop, "click", function(e) {
+      renderer.zoomOut();
+    });
+    utils.appendElement(innerContainer, renderer.cancelZoomElement);
+    utils.appendElement(innerContainer, cancelZoomBackdrop);
 
     if (game.boardSize < 7) {
       if (game.boardSize > 1 && game.boardSize % 2 == 1) {
@@ -123,25 +143,211 @@ var DOMRenderer = function(game, boardElement) {
     var boardWidth = ((renderer.INTERSECTION_GAP_SIZE * (game.boardSize - 1)) + (game.boardSize)*1 + (renderer.MARGIN)*2);
     var boardHeight = ((renderer.INTERSECTION_GAP_SIZE * (game.boardSize - 1)) + (game.boardSize)*1 + (renderer.MARGIN)*2);
 
-    boardElement.style.width = boardWidth + "px";
-    boardElement.style.height = boardHeight + "px";
+    innerContainer.style.width = boardWidth + "px";
+    innerContainer.style.height = boardHeight + "px";
+
+    zoomContainer.style.width = boardWidth + "px";
+    zoomContainer.style.height = boardHeight + "px";
 
     utils.flatten(renderer.grid).forEach(function(intersectionEl) {
+      utils.addEventListener(intersectionEl, "touchstart", function() {
+        renderer.touchEventFired = true;
+      });
+
+      utils.addEventListener(intersectionEl, "mouseenter", function() {
+        var intersectionElement = this;
+
+        utils.addClass(intersectionElement, "hovered");
+      });
+
+      utils.addEventListener(intersectionEl, "mouseleave", function() {
+        var intersectionElement = this;
+
+        utils.removeClass(intersectionElement, "hovered");
+        game.renderer.resetTouchedPoint();
+      });
+
       utils.addEventListener(intersectionEl, "click", function() {
         var intersectionElement = this;
         var playedYPosition = Number(intersectionElement.getAttribute("data-position-y"));
         var playedXPosition = Number(intersectionElement.getAttribute("data-position-x"));
 
-        if (game.isOver()) {
-          game.toggleDeadAt(playedYPosition, playedXPosition);
+        var playOrToggleDead = function() {
+          if (game.isOver()) {
+            game.toggleDeadAt(playedYPosition, playedXPosition);
+          } else {
+            game.playAt(playedYPosition, playedXPosition);
+          }
+        };
+
+        // if this isn't part of a touch,
+        // or it is and the user is zoomed in,
+        // or it's game over and we're marking stones dead,
+        // then don't use the zoom/double-select system.
+        if (!renderer.touchEventFired || (document.body.clientWidth / window.innerWidth > 1) || game.isOver()) {
+          playOrToggleDead();
+          return;
+        }
+
+        if (renderer.touchedPoint) {
+          if (intersectionElement == renderer.touchedPoint) {
+            playOrToggleDead();
+          } else {
+            renderer.showPossibleMoveAt(intersectionElement);
+          }
         } else {
-          game.playAt(playedYPosition, playedXPosition);
+          renderer.showPossibleMoveAt(intersectionElement);
         }
       });
     });
+
+    var scaleX = innerContainer.parentNode.clientWidth / innerContainer.clientWidth;
+    var scaleY = innerContainer.parentNode.clientHeight / innerContainer.clientHeight;
+    var scale = Math.min(scaleX, scaleY);
+
+    if (scale > 0 && scale < 1) {
+      utils.addClass(boardElement, "tenuki-scaled");
+      innerContainer.style["transform-origin"] = "top left";
+      innerContainer.style.transform = "scale3d(" + scale + ", " + scale + ", 1)";
+
+      // reset the outer element's height to match, ensuring that we free up any lingering whitespace
+      boardElement.style.width = innerContainer.getBoundingClientRect().width + "px";
+      boardElement.style.height = innerContainer.getBoundingClientRect().height + "px";
+    }
+
+    utils.addEventListener(boardElement, "touchstart", function(event) {
+      if (event.touches.length > 1) {
+        return;
+      }
+
+      if (!utils.hasClass(boardElement, "tenuki-zoomed")) {
+        return;
+      }
+
+      var xCursor = event.changedTouches[0].clientX;
+      var yCursor = event.changedTouches[0].clientY;
+
+      renderer.dragStartX = xCursor - this.offsetLeft;
+      renderer.dragStartY = yCursor - this.offsetTop;
+      zoomContainer.style.transition = "none";
+    });
+
+    utils.addEventListener(innerContainer, "touchend", function(event) {
+      if (event.touches.length > 1) {
+        return;
+      }
+
+      if (!utils.hasClass(boardElement, "tenuki-zoomed")) {
+        return;
+      }
+
+      zoomContainer.style.transition = "";
+
+      if (!renderer.moveInProgress) {
+        return;
+      }
+      renderer.translateY = renderer.lastTranslateY;
+      renderer.translateX = renderer.lastTranslateX;
+      renderer.moveInProgress = false;
+    });
+
+    utils.addEventListener(innerContainer, "touchmove", function(event) {
+      if (event.touches.length > 1) {
+        return;
+      }
+
+      if (!utils.hasClass(boardElement, "tenuki-zoomed")) {
+        return true;
+      }
+
+      // prevent pull-to-refresh
+      event.preventDefault();
+
+      renderer.moveInProgress = true;
+
+      var xCursor = event.changedTouches[0].clientX;
+      var yCursor = event.changedTouches[0].clientY;
+
+      var deltaX = xCursor - renderer.dragStartX;
+      var deltaY = yCursor - renderer.dragStartY;
+
+      var translateY = renderer.translateY + deltaY/2.5;
+      var translateX = renderer.translateX + deltaX/2.5;
+
+      if (translateY > 0.5*innerContainer.clientHeight - renderer.MARGIN) {
+        translateY = 0.5*innerContainer.clientHeight - renderer.MARGIN;
+      }
+
+      if (translateX > 0.5*innerContainer.clientWidth - renderer.MARGIN) {
+        translateX = 0.5*innerContainer.clientWidth - renderer.MARGIN;
+      }
+
+      if (translateY < -0.5*innerContainer.clientHeight + renderer.MARGIN) {
+        translateY = -0.5*innerContainer.clientHeight + renderer.MARGIN;
+      }
+
+      if (translateX < -0.5*innerContainer.clientWidth + renderer.MARGIN) {
+        translateX = -0.5*innerContainer.clientWidth + renderer.MARGIN;
+      }
+
+      zoomContainer.style.transform = "translate3d(" + 2.5*translateX + "px, " + 2.5*translateY + "px, 0) scale3d(2.5, 2.5, 1)";
+
+      renderer.lastTranslateX = translateX;
+      renderer.lastTranslateY = translateY;
+    });
   }
 
+  this.showPossibleMoveAt = function(intersectionElement) {
+    var renderer = this;
+    var boardElement = this.boardElement;
+    var innerContainer = this.innerContainer;
+    var zoomContainer = this.zoomContainer;
+
+    renderer.touchedPoint = intersectionElement;
+
+    if (utils.hasClass(boardElement, "tenuki-scaled")) {
+      var top = intersectionElement.offsetTop;
+      var left = intersectionElement.offsetLeft;
+
+      var translateY = 0.5 * zoomContainer.clientHeight - top - renderer.MARGIN;
+      var translateX = 0.5 * zoomContainer.clientWidth - left - renderer.MARGIN;
+
+      zoomContainer.style.transform = "translate3d(" + 2.5*translateX + "px, " + 2.5*translateY + "px, 0) scale3d(2.5, 2.5, 1)";
+      renderer.translateY = translateY;
+      renderer.translateX = translateX;
+
+      utils.addClass(renderer.cancelZoomElement, "visible");
+      utils.addClass(renderer.boardElement, "tenuki-zoomed");
+    }
+  };
+
+  this.resetTouchedPoint = function() {
+    var renderer = this;
+
+    renderer.touchedPoint = null;
+  }
+
+  this.zoomOut = function() {
+    var renderer = this;
+    var zoomContainer = renderer.zoomContainer;
+
+    this.resetTouchedPoint();
+    zoomContainer.style.transform = "";
+    zoomContainer.style.transition = "";
+    renderer.dragStartX = null;
+    renderer.dragStartY = null;
+    renderer.translateY = null;
+    renderer.translateX = null;
+    renderer.lastTranslateX = null;
+    renderer.lastTranslateY = null;
+
+    utils.removeClass(renderer.cancelZoomElement, "visible");
+    utils.removeClass(renderer.boardElement, "tenuki-zoomed");
+  };
+
   this.render = function() {
+    this.resetTouchedPoint();
+
     this.renderStonesPlayed();
     this.updateMarkerPoints();
     this.updateCurrentPlayer();

--- a/css/board.css
+++ b/css/board.css
@@ -1,6 +1,60 @@
 .tenuki-board {
   position: relative;
+  -webkit-user-select: none;
+}
+
+.tenuki-board .tenuki-inner-container {
   background: rgb(226, 188, 106);
+  overflow: hidden;
+}
+
+.tenuki-board .tenuki-zoom-container {
+  transition: transform 0.2s ease-in-out;
+  /*
+   * address an issue somewhat related to the shrink-to-fit problem on iOS 9: https://forums.developer.apple.com/thread/13510
+   * by setting this initial scale, any subsequent shrinking will not leave whitespace on the right of the board, which leads
+   * to a horizontal scrollbar
+   */
+  transform: scale(1);
+}
+
+.tenuki-board.tenuki-scaled .cancel-zoom.visible {
+  background: #B95858;
+  height: 70px;
+  width: 20px;
+  position: absolute;
+  transform: rotateZ(45deg);
+  bottom: 62px;
+  left: 89px;
+  z-index: 2;
+}
+
+.tenuki-board.tenuki-scaled .cancel-zoom.visible:after {
+  background: #B95858;
+  content: "";
+  height: 20px;
+  left: -25px;
+  position: absolute;
+  top: 25px;
+  width: 70px;
+}
+
+.tenuki-board.tenuki-scaled .cancel-zoom.visible + .cancel-zoom-backdrop {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  z-index: 1;
+  bottom: 48px;
+  left: 49px;
+  background: rgba(226, 188, 106, 0.81);
+  border-radius: 50%;
+}
+
+.tenuki-board[data-include-gutter=true] .cancel-zoom.visible,
+.tenuki-board[data-include-gutter=true] .cancel-zoom.visible + .cancel-zoom-backdrop {
+  /* additional gutter margin offset */
+  margin-left: calc(28px - 3px);
+  margin-bottom: calc(28px - 3px);
 }
 
 .tenuki-board .lines {
@@ -187,7 +241,7 @@
   height: 100%;
 }
 
-.tenuki-board .intersection.empty:hover .highlight {
+.tenuki-board .intersection.empty.hovered .highlight {
   display: block;
   /* stone width without border */
   width: calc(28px - 1px);
@@ -197,13 +251,13 @@
   opacity: 0.5;
 }
 
-.tenuki-board.white-to-play .intersection.empty:hover .highlight,
-.tenuki-board.black-to-play .intersection.empty:hover .highlight {
+.tenuki-board.white-to-play .intersection.empty.hovered .highlight,
+.tenuki-board.black-to-play .intersection.empty.hovered .highlight {
   background: black;
   border: 1px solid black;
 }
 
-.tenuki-board.white-to-play .intersection.empty:hover .highlight {
+.tenuki-board.white-to-play .intersection.empty.hovered .highlight {
   background: white;
 }
 
@@ -268,13 +322,13 @@
 }
 
 .tenuki-board-textured .stone.black,
-.tenuki-board-textured.black-to-play .intersection.empty:hover .highlight {
+.tenuki-board-textured.black-to-play .intersection.empty.hovered .highlight {
   border-color: #565656;
   background: radial-gradient(circle at 50% 120%, #000000, #484848 10%, #101010 80%, #FFFFFF 100%);
 }
 
 .tenuki-board-textured .stone.white,
-.tenuki-board-textured.white-to-play .intersection.empty:hover .highlight {
+.tenuki-board-textured.white-to-play .intersection.empty.hovered .highlight {
   border-color: #DEDEDE;
   background: radial-gradient(circle at 50% 120%, #ECEAEA, #D6D6D6 10%, #EAEAEA 80%, #FFFFFF 100%);
 }

--- a/examples/example-controls.js
+++ b/examples/example-controls.js
@@ -1,0 +1,82 @@
+// An example setup showing how buttons could be set to board/game functionality.
+ExampleGameControls = function(element, game) {
+  this.element = element;
+  this.game = game;
+  this.textInfo = element.querySelector(".text-info p");
+  this.gameInfo = element.querySelector(".game-info p");
+
+  this.setText = function(str) {
+    this.textInfo.innerText = str;
+  };
+
+  this.updateStats = function() {
+    var newGameInfo = "";
+    newGameInfo += "Black stones captured: " + this.game.captures["black"];
+    newGameInfo += "\n\n";
+    newGameInfo +=  "White stones captured: " + this.game.captures["white"];
+    newGameInfo += "\n\n";
+
+    newGameInfo += "Move " + this.game.moves.length;
+    newGameInfo += "\n\n";
+
+    var currentMove = this.game.currentMove();
+
+    if (currentMove) {
+      var player = currentMove.color[0].toUpperCase() + currentMove.color.substr(1);
+
+      if (currentMove.pass) {
+        newGameInfo += player + " passed."
+      }
+    }
+
+    this.gameInfo.innerText = newGameInfo;
+
+    if (typeof currentMove != "undefined" && currentMove.pass) {
+      var str = "";
+
+      if (this.game.isOver()) {
+        str += "Game over.";
+        str += "\n\n"
+        str += "Territory scoring: Black has " + this.game.territoryScore().black;
+        str += "\n\n";
+        str += "Territory scoring: White has " + this.game.territoryScore().white;
+        str += "\n\n"
+        str += "Area scoring: Black has " + this.game.areaScore().black;
+        str += "\n\n"
+        str += "Area scoring: White has " + this.game.areaScore().white;
+      }
+
+      this.setText(str)
+    } else {
+      this.setText("");
+    }
+  };
+
+  this.setup = function() {
+    var controls = this;
+
+    var passButton = document.querySelector(".pass");
+    var undoButton = document.querySelector(".undo");
+    var texturedButton = document.querySelector(".textured");
+
+    passButton.addEventListener("click", function(e) {
+      e.preventDefault();
+
+      var player = controls.game.currentPlayer;
+      controls.game.pass();
+      controls.updateStats();
+    });
+
+    undoButton.addEventListener("click", function(e) {
+      e.preventDefault();
+
+      controls.game.undo();
+    });
+
+    texturedButton.addEventListener("click", function(e) {
+      e.preventDefault();
+
+      controls.game.renderer.boardElement.classList.toggle("tenuki-board-textured");
+    });
+  }
+};

--- a/examples/example.css
+++ b/examples/example.css
@@ -1,0 +1,56 @@
+body { margin: 0; }
+
+.tenuki-board {
+  max-width: 100%;
+}
+
+ @media (orientation:landscape) {
+  html, body { height: 100%; }
+
+  .tenuki-board {
+    max-width: none;
+    max-height: 100%;
+  }
+ }
+
+.tenuki-board,
+.controls {
+  float: left;
+}
+
+.controls {
+  margin-left: 10px;
+  overflow: auto;
+  margin-top: 18px;
+}
+
+.controls a + a {
+  margin-left: 1em;
+}
+
+.controls .game-info {
+  padding: 0.3em 0.5em;
+}
+
+.controls .text-info {
+  clear: both;
+  height: 90%;
+  overflow: auto;
+  padding: 0.5em;
+}
+
+.controls a {
+  display: inline-block;
+  height: 100%;
+  font-size: 1em;
+  text-decoration: none;
+  color: inherit;
+  padding: 0.3em 0.5em;
+  border-radius: 7px;
+  background: gray;
+  color: white;
+}
+
+.controls p {
+  margin-top: 1em;
+}

--- a/examples/example.html
+++ b/examples/example.html
@@ -5,6 +5,9 @@
 <head>
   <link rel="stylesheet" href="../build/tenuki.css"></link>
   <script src="../build/tenuki.js"></script>
+
+  <link rel="stylesheet" href="example.css"></link>
+  <script src="example-controls.js"></script>
 </head>
 
 <div class="tenuki-board"></div>

--- a/examples/example_multiboard.html
+++ b/examples/example_multiboard.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
+
+<head>
+  <link rel="stylesheet" href="../build/tenuki.css"></link>
+  <script src="../build/tenuki.js"></script>
+
+  <link rel="stylesheet" href="example.css"></link>
+  <script src="example-controls.js"></script>
+
+  <style>
+    #board-2 {
+      margin-top: 1em;
+    }
+  </style>
+</head>
+
+<div id="board-1" class="tenuki-board"></div>
+<div id="board-2" class="tenuki-board"></div>
+
+<script>
+  boardElement_1 = document.querySelector("#board-1");
+  window.board_1 = new tenuki.Game(boardElement_1, 9);
+  window.board_1.setup();
+
+  boardElement_2 = document.querySelector("#board-2");
+  window.board_2 = new tenuki.Game(boardElement_2, 9);
+  window.board_2.setup();
+</script>

--- a/examples/example_with_simple_controls.html
+++ b/examples/example_with_simple_controls.html
@@ -6,50 +6,8 @@
   <link rel="stylesheet" href="../build/tenuki.css"></link>
   <script src="../build/tenuki.js"></script>
 
-  <style>
-    .tenuki-board,
-    .controls {
-      float: left;
-    }
-
-    .controls {
-      margin-left: 10px;
-      height: 50%;
-      width: 400px;
-      overflow: hidden;
-    }
-
-    .controls a + a {
-      margin-left: 1em;
-    }
-
-    .controls .game-info {
-      padding: 0.3em 0.5em;
-    }
-
-    .controls .text-info {
-      clear: both;
-      height: 90%;
-      overflow: auto;
-      padding: 0.5em;
-    }
-
-    .controls a {
-      display: inline-block;
-      height: 100%;
-      font-size: 1em;
-      text-decoration: none;
-      color: inherit;
-      padding: 0.3em 0.5em;
-      border-radius: 7px;
-      background: gray;
-      color: white;
-    }
-
-    .controls p {
-      margin-top: 1em;
-    }
-</style>
+  <link rel="stylesheet" href="example.css"></link>
+  <script src="example-controls.js"></script>
 </head>
 
 <div class="tenuki-board"></div>
@@ -66,89 +24,6 @@
 </div>
 
 <script>
-// An example setup showing how buttons could be set to board/game functionality.
-ExampleGameControls = function(element, game) {
-  this.element = element;
-  this.game = game;
-  this.textInfo = element.querySelector(".text-info p");
-  this.gameInfo = element.querySelector(".game-info p");
-
-  this.setText = function(str) {
-    this.textInfo.innerText = str;
-  };
-
-  this.updateStats = function() {
-    var newGameInfo = "";
-    newGameInfo += "Black stones captured: " + this.game.captures["black"];
-    newGameInfo += "\n\n";
-    newGameInfo +=  "White stones captured: " + this.game.captures["white"];
-    newGameInfo += "\n\n";
-
-    newGameInfo += "Move " + this.game.moves.length;
-    newGameInfo += "\n\n";
-
-    var currentMove = this.game.currentMove();
-
-    if (currentMove) {
-      var player = currentMove.color[0].toUpperCase() + currentMove.color.substr(1);
-
-      if (currentMove.pass) {
-        newGameInfo += player + " passed."
-      }
-    }
-
-    this.gameInfo.innerText = newGameInfo;
-
-    if (typeof currentMove != "undefined" && currentMove.pass) {
-      var str = "";
-
-      if (this.game.isOver()) {
-        str += "Game over.";
-        str += "\n\n"
-        str += "Territory scoring: Black has " + this.game.territoryScore().black;
-        str += "\n\n";
-        str += "Territory scoring: White has " + this.game.territoryScore().white;
-        str += "\n\n"
-        str += "Area scoring: Black has " + this.game.areaScore().black;
-        str += "\n\n"
-        str += "Area scoring: White has " + this.game.areaScore().white;
-      }
-
-      this.setText(str)
-    } else {
-      this.setText("");
-    }
-  };
-
-  this.setup = function() {
-    var controls = this;
-
-    var passButton = document.querySelector(".pass");
-    var undoButton = document.querySelector(".undo");
-    var texturedButton = document.querySelector(".textured");
-
-    passButton.addEventListener("click", function(e) {
-      e.preventDefault();
-
-      var player = controls.game.currentPlayer;
-      controls.game.pass();
-      controls.updateStats();
-    });
-
-    undoButton.addEventListener("click", function(e) {
-      e.preventDefault();
-
-      controls.game.undo();
-    });
-
-    texturedButton.addEventListener("click", function(e) {
-      e.preventDefault();
-
-      controls.game.renderer.boardElement.classList.toggle("tenuki-board-textured");
-    });
-  }
-};
-
 var boardElement = document.querySelector(".tenuki-board");
 var game = new tenuki.Game(boardElement);
 game.setup();

--- a/examples/example_with_simple_controls_and_gutter.html
+++ b/examples/example_with_simple_controls_and_gutter.html
@@ -6,50 +6,8 @@
   <link rel="stylesheet" href="../build/tenuki.css"></link>
   <script src="../build/tenuki.js"></script>
 
-  <style>
-    .tenuki-board,
-    .controls {
-      float: left;
-    }
-
-    .controls {
-      margin-left: 10px;
-      height: 50%;
-      width: 400px;
-      overflow: hidden;
-    }
-
-    .controls a + a {
-      margin-left: 1em;
-    }
-
-    .controls .game-info {
-      padding: 0.3em 0.5em;
-    }
-
-    .controls .text-info {
-      clear: both;
-      height: 90%;
-      overflow: auto;
-      padding: 0.5em;
-    }
-
-    .controls a {
-      display: inline-block;
-      height: 100%;
-      font-size: 1em;
-      text-decoration: none;
-      color: inherit;
-      padding: 0.3em 0.5em;
-      border-radius: 7px;
-      background: gray;
-      color: white;
-    }
-
-    .controls p {
-      margin-top: 1em;
-    }
-</style>
+  <link rel="stylesheet" href="example.css"></link>
+  <script src="example-controls.js"></script>
 </head>
 
 <div class="tenuki-board" data-include-gutter=true></div>
@@ -66,91 +24,6 @@
 </div>
 
 <script>
-// An example setup showing how buttons could be set to game/board functionality.
-ExampleGameControls = function(element, game) {
-  this.element = element;
-  this.game = game;
-  this.textInfo = element.querySelector(".text-info p");
-  this.gameInfo = element.querySelector(".game-info p");
-
-  this.setText = function(str) {
-    this.textInfo.innerText = str;
-  };
-
-  this.updateStats = function() {
-    var newGameInfo = "";
-    newGameInfo += "Black stones captured: " + this.game.captures["black"];
-    newGameInfo += "\n\n";
-    newGameInfo +=  "White stones captured: " + this.game.captures["white"];
-    newGameInfo += "\n\n";
-
-    newGameInfo += "Move " + this.game.moves.length;
-    newGameInfo += "\n\n";
-
-    var currentMove = this.game.currentMove();
-
-    if (currentMove) {
-      var player = currentMove.color[0].toUpperCase() + currentMove.color.substr(1);
-
-      if (!currentMove.pass) {
-        newGameInfo += player + " played " + currentMove.coordinates;
-      } else {
-        newGameInfo += player + " passed."
-      }
-    }
-
-    this.gameInfo.innerText = newGameInfo;
-
-    if (typeof currentMove != "undefined" && currentMove.pass) {
-      var str = "";
-
-      if (this.game.isOver()) {
-        str += "Game over.";
-        str += "\n\n"
-        str += "Territory scoring: Black has " + this.game.territoryScore().black;
-        str += "\n\n";
-        str += "Territory scoring: White has " + this.game.territoryScore().white;
-        str += "\n\n"
-        str += "Area scoring: Black has " + this.game.areaScore().black;
-        str += "\n\n"
-        str += "Area scoring: White has " + this.game.areaScore().white;
-      }
-
-      this.setText(str)
-    } else {
-      this.setText("");
-    }
-  };
-
-  this.setup = function() {
-    var controls = this;
-
-    var passButton = document.querySelector(".pass");
-    var undoButton = document.querySelector(".undo");
-    var texturedButton = document.querySelector(".textured");
-
-    passButton.addEventListener("click", function(e) {
-      e.preventDefault();
-
-      var player = controls.game.currentPlayer;
-      controls.game.pass();
-      controls.updateStats();
-    });
-
-    undoButton.addEventListener("click", function(e) {
-      e.preventDefault();
-
-      controls.game.undo();
-    });
-
-    texturedButton.addEventListener("click", function(e) {
-      e.preventDefault();
-
-      controls.game.renderer.boardElement.classList.toggle("tenuki-board-textured");
-    });
-  }
-};
-
 var boardElement = document.querySelector(".tenuki-board");
 var game = new tenuki.Game(boardElement);
 game.setup();

--- a/lib/dom-renderer.js
+++ b/lib/dom-renderer.js
@@ -8,16 +8,36 @@ var DOMRenderer = function(game, boardElement) {
   this.game = game;
   this.boardElement = boardElement;
   this.grid = [];
+  this.touchEventFired = false;
 
   this.setup = function() {
     var renderer = this;
     var game = renderer.game;
     var boardElement = this.boardElement;
 
-    utils.appendElement(boardElement, utils.createElement("div", { class: "lines horizontal" }));
-    utils.appendElement(boardElement, utils.createElement("div", { class: "lines vertical" }));
-    utils.appendElement(boardElement, utils.createElement("div", { class: "hoshi-points" }));
-    utils.appendElement(boardElement, utils.createElement("div", { class: "intersections" }));
+    var innerContainer = utils.createElement("div", { class: "tenuki-inner-container" });
+    renderer.innerContainer = innerContainer;
+    utils.appendElement(boardElement, innerContainer);
+
+    var zoomContainer = utils.createElement("div", { class: "tenuki-zoom-container" });
+    renderer.zoomContainer = zoomContainer;
+    utils.appendElement(innerContainer, zoomContainer);
+
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "lines horizontal" }));
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "lines vertical" }));
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "hoshi-points" }));
+    utils.appendElement(zoomContainer, utils.createElement("div", { class: "intersections" }));
+
+    renderer.cancelZoomElement = utils.createElement("div", { class: "cancel-zoom" });
+    cancelZoomBackdrop = utils.createElement("div", { class: "cancel-zoom-backdrop" });
+    utils.addEventListener(renderer.cancelZoomElement, "click", function(e) {
+      renderer.zoomOut();
+    });
+    utils.addEventListener(cancelZoomBackdrop, "click", function(e) {
+      renderer.zoomOut();
+    });
+    utils.appendElement(innerContainer, renderer.cancelZoomElement);
+    utils.appendElement(innerContainer, cancelZoomBackdrop);
 
     if (game.boardSize < 7) {
       if (game.boardSize > 1 && game.boardSize % 2 == 1) {
@@ -113,25 +133,211 @@ var DOMRenderer = function(game, boardElement) {
     var boardWidth = ((renderer.INTERSECTION_GAP_SIZE * (game.boardSize - 1)) + (game.boardSize)*1 + (renderer.MARGIN)*2);
     var boardHeight = ((renderer.INTERSECTION_GAP_SIZE * (game.boardSize - 1)) + (game.boardSize)*1 + (renderer.MARGIN)*2);
 
-    boardElement.style.width = boardWidth + "px";
-    boardElement.style.height = boardHeight + "px";
+    innerContainer.style.width = boardWidth + "px";
+    innerContainer.style.height = boardHeight + "px";
+
+    zoomContainer.style.width = boardWidth + "px";
+    zoomContainer.style.height = boardHeight + "px";
 
     utils.flatten(renderer.grid).forEach(function(intersectionEl) {
+      utils.addEventListener(intersectionEl, "touchstart", function() {
+        renderer.touchEventFired = true;
+      });
+
+      utils.addEventListener(intersectionEl, "mouseenter", function() {
+        var intersectionElement = this;
+
+        utils.addClass(intersectionElement, "hovered");
+      });
+
+      utils.addEventListener(intersectionEl, "mouseleave", function() {
+        var intersectionElement = this;
+
+        utils.removeClass(intersectionElement, "hovered");
+        game.renderer.resetTouchedPoint();
+      });
+
       utils.addEventListener(intersectionEl, "click", function() {
         var intersectionElement = this;
         var playedYPosition = Number(intersectionElement.getAttribute("data-position-y"));
         var playedXPosition = Number(intersectionElement.getAttribute("data-position-x"));
 
-        if (game.isOver()) {
-          game.toggleDeadAt(playedYPosition, playedXPosition);
+        var playOrToggleDead = function() {
+          if (game.isOver()) {
+            game.toggleDeadAt(playedYPosition, playedXPosition);
+          } else {
+            game.playAt(playedYPosition, playedXPosition);
+          }
+        };
+
+        // if this isn't part of a touch,
+        // or it is and the user is zoomed in,
+        // or it's game over and we're marking stones dead,
+        // then don't use the zoom/double-select system.
+        if (!renderer.touchEventFired || (document.body.clientWidth / window.innerWidth > 1) || game.isOver()) {
+          playOrToggleDead();
+          return;
+        }
+
+        if (renderer.touchedPoint) {
+          if (intersectionElement == renderer.touchedPoint) {
+            playOrToggleDead();
+          } else {
+            renderer.showPossibleMoveAt(intersectionElement);
+          }
         } else {
-          game.playAt(playedYPosition, playedXPosition);
+          renderer.showPossibleMoveAt(intersectionElement);
         }
       });
     });
+
+    var scaleX = innerContainer.parentNode.clientWidth / innerContainer.clientWidth;
+    var scaleY = innerContainer.parentNode.clientHeight / innerContainer.clientHeight;
+    var scale = Math.min(scaleX, scaleY);
+
+    if (scale > 0 && scale < 1) {
+      utils.addClass(boardElement, "tenuki-scaled");
+      innerContainer.style["transform-origin"] = "top left";
+      innerContainer.style.transform = "scale3d(" + scale + ", " + scale + ", 1)";
+
+      // reset the outer element's height to match, ensuring that we free up any lingering whitespace
+      boardElement.style.width = innerContainer.getBoundingClientRect().width + "px";
+      boardElement.style.height = innerContainer.getBoundingClientRect().height + "px";
+    }
+
+    utils.addEventListener(boardElement, "touchstart", function(event) {
+      if (event.touches.length > 1) {
+        return;
+      }
+
+      if (!utils.hasClass(boardElement, "tenuki-zoomed")) {
+        return;
+      }
+
+      var xCursor = event.changedTouches[0].clientX;
+      var yCursor = event.changedTouches[0].clientY;
+
+      renderer.dragStartX = xCursor - this.offsetLeft;
+      renderer.dragStartY = yCursor - this.offsetTop;
+      zoomContainer.style.transition = "none";
+    });
+
+    utils.addEventListener(innerContainer, "touchend", function(event) {
+      if (event.touches.length > 1) {
+        return;
+      }
+
+      if (!utils.hasClass(boardElement, "tenuki-zoomed")) {
+        return;
+      }
+
+      zoomContainer.style.transition = "";
+
+      if (!renderer.moveInProgress) {
+        return;
+      }
+      renderer.translateY = renderer.lastTranslateY;
+      renderer.translateX = renderer.lastTranslateX;
+      renderer.moveInProgress = false;
+    });
+
+    utils.addEventListener(innerContainer, "touchmove", function(event) {
+      if (event.touches.length > 1) {
+        return;
+      }
+
+      if (!utils.hasClass(boardElement, "tenuki-zoomed")) {
+        return true;
+      }
+
+      // prevent pull-to-refresh
+      event.preventDefault();
+
+      renderer.moveInProgress = true;
+
+      var xCursor = event.changedTouches[0].clientX;
+      var yCursor = event.changedTouches[0].clientY;
+
+      var deltaX = xCursor - renderer.dragStartX;
+      var deltaY = yCursor - renderer.dragStartY;
+
+      var translateY = renderer.translateY + deltaY/2.5;
+      var translateX = renderer.translateX + deltaX/2.5;
+
+      if (translateY > 0.5*innerContainer.clientHeight - renderer.MARGIN) {
+        translateY = 0.5*innerContainer.clientHeight - renderer.MARGIN;
+      }
+
+      if (translateX > 0.5*innerContainer.clientWidth - renderer.MARGIN) {
+        translateX = 0.5*innerContainer.clientWidth - renderer.MARGIN;
+      }
+
+      if (translateY < -0.5*innerContainer.clientHeight + renderer.MARGIN) {
+        translateY = -0.5*innerContainer.clientHeight + renderer.MARGIN;
+      }
+
+      if (translateX < -0.5*innerContainer.clientWidth + renderer.MARGIN) {
+        translateX = -0.5*innerContainer.clientWidth + renderer.MARGIN;
+      }
+
+      zoomContainer.style.transform = "translate3d(" + 2.5*translateX + "px, " + 2.5*translateY + "px, 0) scale3d(2.5, 2.5, 1)";
+
+      renderer.lastTranslateX = translateX;
+      renderer.lastTranslateY = translateY;
+    });
   }
 
+  this.showPossibleMoveAt = function(intersectionElement) {
+    var renderer = this;
+    var boardElement = this.boardElement;
+    var innerContainer = this.innerContainer;
+    var zoomContainer = this.zoomContainer;
+
+    renderer.touchedPoint = intersectionElement;
+
+    if (utils.hasClass(boardElement, "tenuki-scaled")) {
+      var top = intersectionElement.offsetTop;
+      var left = intersectionElement.offsetLeft;
+
+      var translateY = 0.5 * zoomContainer.clientHeight - top - renderer.MARGIN;
+      var translateX = 0.5 * zoomContainer.clientWidth - left - renderer.MARGIN;
+
+      zoomContainer.style.transform = "translate3d(" + 2.5*translateX + "px, " + 2.5*translateY + "px, 0) scale3d(2.5, 2.5, 1)";
+      renderer.translateY = translateY;
+      renderer.translateX = translateX;
+
+      utils.addClass(renderer.cancelZoomElement, "visible");
+      utils.addClass(renderer.boardElement, "tenuki-zoomed");
+    }
+  };
+
+  this.resetTouchedPoint = function() {
+    var renderer = this;
+
+    renderer.touchedPoint = null;
+  }
+
+  this.zoomOut = function() {
+    var renderer = this;
+    var zoomContainer = renderer.zoomContainer;
+
+    this.resetTouchedPoint();
+    zoomContainer.style.transform = "";
+    zoomContainer.style.transition = "";
+    renderer.dragStartX = null;
+    renderer.dragStartY = null;
+    renderer.translateY = null;
+    renderer.translateX = null;
+    renderer.lastTranslateX = null;
+    renderer.lastTranslateY = null;
+
+    utils.removeClass(renderer.cancelZoomElement, "visible");
+    utils.removeClass(renderer.boardElement, "tenuki-zoomed");
+  };
+
   this.render = function() {
+    this.resetTouchedPoint();
+
     this.renderStonesPlayed();
     this.updateMarkerPoints();
     this.updateCurrentPlayer();


### PR DESCRIPTION
There are 2 main aims here:

1. Automatically shrink the board to fit the containing `.tenuki-board` element's dimensions.
2. Handle touch-based input without an exhausting interface or errors  _everywhere_.

With that in mind, the summary of changes is below, followed by a more in-depth look at the changes and rationale, etc.

For screen captures showing the look and feel, [skip to the next comment](https://github.com/aprescott/tenuki.js/pull/5#issuecomment-206633973).

### Summary

  * `.tenuki-board` can now be set to some size in CSS, and the board contents will automatically scale down to fit that size.
  * For touch inputs: by default, touching an intersection to play a stone will not actually play that stone. It will instead show a preview which is equivalent to a mouse's hover state. Tapping the same previewed intersection a second time will then confirm the state.
  * For touch inputs: if the screen has been zoomed in by the user, toany level above 100%, the preview-double-tap system is skipped. So if you pinch-zoom in, all moves take a single tap.
  * For touch inputs: dead stone marking at the end of the game does not require an initial tap, under any circumstances, because marking stones dead is already an easily-corrected mistake.
  * For touch inputs: If the board has been scaled down by any amount below 100% size, then, in addition to the two-tap preview system, touching an intersection will zoom into the played point, increasing the size of the board to 2.5. Dragging in this mode will move the board around, and a button to cancel will let you zoom all the way back out.

### Automatic shrinking

It should be possible by users of this library to freely set the top-level `.tenuki-board` container to a smaller size depending on the requirements of the page where it's going to be used. Whatever size the `.tenuki-board` container is set to, we scale down to that size if necessary. This allows, for example, a basic setup like this:

```html
<style>
  #my-board { max-width: 100%; }
</style>

<div id="my-board" class="tenuki-board"></div>
```

With this, if the viewport is narrower than the 19x19 board that would be rendered at `#my-board`, then the board should still be usable, without needing to do anything as drastic as, say, require every user of this library to determine what their favourite stone width is.

The approach taken to solve this is fairly basic. Before, there was only one container: `.tenuki-board`. Within this container were the intersections, lines, etc. Instead, there is now an inner container:

```
.tenuki-board
  .inner-container
    [other contents]
```

By adding another wrapper, `.inner-container`, which takes over the previous responsibility of `.tenuki-board`, we are free to let the `.tenuki-board` size dictate the size of the rendered board. If `.inner-container` exceeds the size of `.tenuki-board`, then two steps happen:

  1. Calculate a scaling factor, e.g., the width of `.tenuki-board` divided by the width of `.inner-container`. Let's say it's 0.75, meaning that, in order to fit neatly inside `.tenuki-board`, the rendered contents need to shrink by a scaling factor of 0.75. And that's exactly what we do, with the CSS transform `scale()`.
  2. After `.inner-container` has been rescaled, the dimensions of `.tenuki-board` are fixed to the final computed dimensions of `.inner-container`. The main reason for this is that the board itself has been visually scaled down in proportion, but that leaves whitespace below or to the right, because the original board dimensions are still occupying space. Another reason is that the `<body>` itself may in fact have a shorter height due to the positioning of board elements.

A downside of this is that a refresh is required to rescale the board properly if viewport dimensions change. However, on a phone, this would only really manifest itself as part of an orientation change. It can be more of a problem on desktop though, if you're trying to use a `max-width` setting, since it'll be ignored after step (2) above.

So in summary, what might start like this:

```
[VIEWPORT] -- width 400
  .tenuki-board -- max-width: 100%
    .inner-container -- calculated width for 19x19: 559px
```

Eventually turns into this (with a scaling factor of 400/559, or approximately 0.7156):

```
[VIEWPORT] -- width 400
  .tenuki-board -- width: 400.02...
    .inner-container -- 400.02...
```

### Better touch input

There are various scenarios for touch screens, but a common one is a phone, and a full-sized 19x19 go board on a phone is an intrinsically difficult problem. The opening moves of a go game are across the entire board, yet you can quite quickly need to play out a highly localized sequence of moves.

Given this situation, there are some rudimentary design choices, none of which is all that compelling.

  * Show the board at a fixed 100% size, leaving you to constantly drag to navigate the horizontal scrolling nightmare.
  * Show the board at a smaller size, scaled down (as above, in fact), making it very hard to (a) see the board, and (b) play a position without mistakenly choosing the wrong point. And with this setup:
  * Require the user to repeatedly zoom in, make a play, then zoom out.

The global view leads to many mistakes which have to be corrected. The local view leads to repetitive scrolling or dragging. Moving between them is itself then a chore. Compared to the simplicity of playing a game in person, it would be nice to find something a bit less taxing.

One key change aimed at reducing mistakes is a two-taps-to-play setup. For a touch input, tapping an intersection once will not actually play the stone at that intersection. It will instead only show the same preview that a mouse pointer hover would show. This should alleviate misclicks (which are expensive), albeit at the cost of requiring two taps per move. In an environment where you're playing against another person across a server, where an undo request might not be granted at all, the extra tap is, I think, better.

A second change is the addition of zooming functionality. According to the Internet, the minimum size for a human-friendly touch target is around 26x26 pixels. The width of the grid on a tenuki.js board is around 28x28 pixels at 100% zoom, and so the size of the interaction around an intersection is also around 28x28 pixels. For a mouse it's more than enough, but in the context of hitting a touch target it's cutting it a bit fine. So: zooming.

If you tap an intersection with a touch input device, the preview of the stone is shown, _and_ the board zooms in, centered on that point, scaling the board and everything else up by a factor of 2.5. It's then possible to touch a nearby intersection (which will re-center the board on that point), or touch the same intersection a second time to play the move, or to cancel and zoom back out.

Being zoomed in really makes you want to move around by dragging, so you can do just that: dragging will move around the board.

There are some touch device edge cases here that are taken care of:

  * If the screen has been zoomed in, by any amount, by the user, independent of touching the board, then we don't double up the zoom. If the user has zoomed in, we keep the board as-is at 100%. The thought is that if the user is themselves zooming in, they're in control of what the correct level of zoom is, which is why it's not a requirement that the page itself be unzoomable.
  * If the board was never scaled down to fit its container in the first place, then no zooming happens. It's assumed that the intersection touch targets are big enough at 100% even on a touch display. The two-tap system should hopefully be sufficient at that size to prevent mistakes.
  * Moreover, if the board was never scaled down, touch events don't get hijacked. Doing so would break navigation around the rest of the page, as well as pull-to-refresh functionality, pinch zooming on top of the board, and all manner of other things. Only when zoomed in will dragging be part of a specific board interaction. _Not_ doing this can lead to being completely locked out of the page, so it's important.

One browser quirk to note here is Safari's treatment of a scaled down board. In smoke testing, it was found that Safari on iOS 9 would mistakenly think the board was occupying more horizontal space than it really was. By using `scale(1)` in the initial CSS, when the board is later scaled down on a small screen, a horizontal scroll bar is avoided.