### PR TITLE
End the game after 2 passes even under equivalence scoring rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
 * Change `"superko"` as a ko setting to `"positional-superko"` to be explicit.
+* Two consecutive passes will now always end the game under equivalence scoring. Previously, the requirement that white "pass" last was implemented as a game-ending requirement. Now, the game will always end after 2 passes, with the score handling the extra white pass stone to represent a "pass" move. (#30)
 * `playAt` now returns `false` for a move which is illegal on the basis of ko. Previously it incorrectly returned `null`.
 
 # v0.2.2

--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ game.setup({
 });
 ```
 
-# Configuring scoring and komi
+# Configuring scoring
 
-The default scoring is territory scoring. The scoring can be given as part of the `setup()` options:
+The default scoring method is territory scoring. The scoring rule is configured by `setup()`:
 
 ```js
 game.setup({
@@ -191,10 +191,48 @@ game.setup({
 
 Valid scoring types are:
 
-  * `"area"` — Area scoring.
-  * `"territory"` — Territory scoring.
+  * `"area"`
+  * `"territory"`
+  * `"equivalence"`
 
-The default komi value is 0. To alter the value of white's score, pass `komi`:
+## Area scoring
+
+The score for each player under area scoring is the sum of two values:
+
+* The number of stones on the board.
+* The number of points of territory.
+
+Eyes in seki count as territory under area scoring.
+
+## Territory scoring
+
+The score for each player under territory scoring is simply the number of points of territory.
+
+Eyes in seki _do not_ count as points of territory.
+
+When territory scoring is in use, a simple detection algorithm attempts to correctly ignore each of the following as not-territory:
+
+1. Neutral points, consisting of intersections surrounded by neither player.
+2. Intersections which would be the point of capture for a group in atari, after filling in neutral points.
+3. Eyes in seki.
+
+Counting eyes in seki relies on a way of determining whether a group of stones is in seki. Tenuki detects seki by counting eyes, after filling in other neutral points.
+
+The more neutral points exist on the board, the more likely it is that seki detection will fail in some way.
+
+_It is strongly recommended that you fill in all neutral points before passing at the end of a game._
+
+## Equivalence scoring
+
+An explanation of equivalence scoring can be found at the [Sensei's Library Wiki](http://senseis.xmp.net/?EquivalenceScoring), and a longer explanation of the equivalence can be found in a [commentary appendix to the AGA Rules](https://www.cs.cmu.edu/~wjh/go/rules/AGA.commentary.html).
+
+In short, equivalence scoring implements pass stones, plus the requirement that white make one final pass prior to scoring, which makes the score from counting by area equivalent to the score from counting by territory.
+
+Note that using equivalence scoring does _not_ change how the game ends. The game will end with 2 consecutive passes, even if black makes the 2nd pass. The final white pass stone handed to black is implemented in Tenuki by the `game.score()` function, not a move by a player.
+
+# Komi
+
+The default komi value is 0. To alter the value of white's score, pass `komi` to `setup()`:
 
 ```js
 game.setup({

--- a/src/game.js
+++ b/src/game.js
@@ -71,8 +71,6 @@ Game.prototype = {
       throw new Error("Unknown renderer: " + renderer);
     }
 
-    this._whiteMustPassLast = this._scorer.usingPassStones();
-
     this._ruleset = new Ruleset({
       koRule: koRule
     });
@@ -212,17 +210,10 @@ Game.prototype = {
       return false;
     }
 
-    if (this._whiteMustPassLast) {
-      const finalMove = this._moves[this._moves.length - 1];
-      const previousMove = this._moves[this._moves.length - 2];
+    const finalMove = this._moves[this._moves.length - 1];
+    const previousMove = this._moves[this._moves.length - 2];
 
-      return finalMove.pass && previousMove.pass && finalMove.color === "white";
-    } else {
-      const finalMove = this._moves[this._moves.length - 1];
-      const previousMove = this._moves[this._moves.length - 2];
-
-      return finalMove.pass && previousMove.pass;
-    }
+    return finalMove.pass && previousMove.pass;
   },
 
   toggleDeadAt: function(y, x) {

--- a/src/scorer.js
+++ b/src/scorer.js
@@ -174,8 +174,21 @@ Scorer.prototype = {
     result.white += this._komi;
 
     if (this._usePassStones) {
+      // Under equivalence scoring, 2 consecutive passes signals(!) the end of the
+      // game, but just prior to the end of the game, white must make one final
+      // pass move if the game didn't end on a white pass.
+      //
+      // However, instead of creating a 3rd consecutive pass in the board state,
+      // white's additional pass stone is handled by the scoring mechanism alone.
+      // The idea is that, under any game resumption, the additional white pass
+      // stone must not exist, so we shouldn't add it.
+      //
+      // NOTE: the final result should rely on this scoring function. Any calculations
+      // using raw board state pass stone numbers may be off by 1 in favor of black.
+      const needsFinalWhitePassStone = game.currentState().color !== "white";
+
       return {
-        black: result.black + game.currentState().whitePassStones,
+        black: result.black + game.currentState().whitePassStones + (needsFinalWhitePassStone ? 1 : 0),
         white: result.white + game.currentState().blackPassStones
       };
     } else {

--- a/test/game-scoring-test.js
+++ b/test/game-scoring-test.js
@@ -123,9 +123,6 @@ describe("scoring rules", function() {
 
       setupCaptures(game);
 
-      // pass once more for equivalence scoring
-      expect(game.pass()).to.be.true;
-
       expect(game.isOver()).to.be.true;
 
       // territory + stones on the board + 2 pass stones
@@ -149,8 +146,7 @@ describe("scoring rules", function() {
       expect(game.score().white).to.equal(9*19 + 1);
     });
 
-    // TODO: this requirement is incorrect in its implementation!
-    it("requires one final pass by white", function() {
+    it("adds one final pass stone by white if necessary", function() {
       var game = new Game();
       game.setup({ scoring: "equivalence" });
 
@@ -158,26 +154,25 @@ describe("scoring rules", function() {
       game.pass(); // w
 
       expect(game.isOver()).to.be.true;
+      expect(game.score().black).to.equal(1);
+      expect(game.score().white).to.equal(1);
 
       game = new Game();
       game.setup({ scoring: "equivalence" });
 
-      game.pass(); // b
-      game.pass(); // w
       game.playAt(1, 1); // b
       game.pass(); // w
       game.pass(); // b
 
-      expect(game.isOver()).to.be.false;
-
-      game.pass();
-
       expect(game.isOver()).to.be.true;
+      // area + extra pass stone
+      expect(game.score().black).to.equal(19*19 + 1 + 1);
+      expect(game.score().white).to.equal(1);
     });
   });
 
   describe("territory scoring", function() {
-    it("counts only territory, excluding stones played, plus captures, ", function() {
+    it("counts only territory, excluding stones played, plus captures", function() {
       var game = run("territory");
 
       expect(game.score().black).to.equal(9*19);


### PR DESCRIPTION
The previous implementation of equivalence scoring was incorrect. 3 passes are not required to end the game if the 2nd pass is by black.

Instead, the end of the game is _signaled_ by 2 consecutive passes, and an agreement phase begins. After that agreement phase is over, then white may be required to hand over one final pass stone. If there are any disputes, then white's 3rd and final "pass" never happens.

This commit stops adding a 3rd consecutive white pass to the board state and moves the "final white pass" logic into the scoring step.